### PR TITLE
update version to 1.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ def read(*names, **kwargs):
 
 
 setup(name='jupyter_latex_envs',
-      version='1.3.8.4',
+      version='1.4.0',
       description=("Jupyter notebook extension which supports (some) LaTeX environments "  # noqa
       "within markdown cells. Also provides support for labels and crossreferences, "  # noqa
       "document wide numbering, bibliography, and more..."),

--- a/src/latex_envs/__init__.py
+++ b/src/latex_envs/__init__.py
@@ -1,8 +1,10 @@
 # coding: utf-8
 
-__version__ = '1.2.0'
-
 from . import latex_envs
+
+
+__version__ = '1.4.0'
+
 
 def _jupyter_nbextension_paths():
     return [dict(


### PR DESCRIPTION
I've switched the minor version, since for [semantic versioning](http://semver.org/), new features added in a backwards-compatible manner should increment the minor version, and new features (e.g. comment environment) have been added since 1.3.8.4.

Assuming this makes sense (I may well have missed something!), could we get the new version on pypi also?