### PR TITLE
Remove shortcut for definitio

### DIFF
--- a/src/latex_envs/static/envsLatex.json
+++ b/src/latex_envs/static/envsLatex.json
@@ -14,7 +14,7 @@
    "definition": {
        "name": "definition",
        "hint": "Insert a definition",
-       "shortcut": "Ctrl-D",
+       "shortcut": "",
        "env": "\\begin{definition}\\label{def:}\n\n\\end{definition}\n"
    },
    "theorem": {


### PR DESCRIPTION
This is inconsistent with the `envsLatex.js` file. It also is commonly used to duplicate a line with `Ctrl-D`.