### PR TITLE
Python3 fixes

### DIFF
--- a/src/latex_envs/__init__.py
+++ b/src/latex_envs/__init__.py
@@ -3,7 +3,7 @@
 from . import latex_envs
 
 
-__version__ = '1.4.0'
+__version__ = '1.4.1'
 
 
 def _jupyter_nbextension_paths():

--- a/src/latex_envs/latex_envs.py
+++ b/src/latex_envs/latex_envs.py
@@ -414,6 +414,8 @@ class LenvsLatexExporter(LatexExporter):
     Exports to a LaTeX document
     """
 
+    config_title = Bool(
+        True, help="Proper Title Format").tag(config=True, alias="rh")
     removeHeaders = Bool(
         False, help="Remove headers and footers").tag(config=True, alias="rh")
     figcaptionProcess = Bool(
@@ -501,8 +503,15 @@ class LenvsLatexExporter(LatexExporter):
         newtext = re.sub('\\\\begin{verbatim}[\s]*?<IPython\.core\.display[\S ]*?>[\s]*?\\\\end{verbatim}', '', newtext, flags=re.M)  # noqa
         # bottom page with links to Index/back/next (suppress this)
         # '----[\s]*?<div align=right> [Index](toc.ipynb)[\S ]*?.ipynb\)</div>'
-        newtext = re.sub('\\\\begin{center}\\\\rule{[\S\s]*?\\\\end{center}[\s]*?\S*\href{toc.ipynb}{Index}[\S\s ]*?.ipynb}{Next}', '', newtext, flags=re.M)  # noqa
+        newtext = re.sub('\\\\begin{center}\\\\rule{[\S\s]*?\\\\end{center}[\s]*?\S*\\\\href{toc.ipynb}{Index}[\S\s ]*?.ipynb}{Next}', '', newtext, flags=re.M)  # noqa
         return newtext
+
+    def configure_title(self, nb_text):
+        # get rid of the first \maketitle command which is in the wrong place
+        nb_text = nb_text.replace('\\maketitle', '',  1)
+        # replace the second (correctly placed) \maketitle command with itself, and make a TOC (table of contents) on the next line
+        nb_text = nb_text.replace('\\maketitle', '\\maketitle\n\\tableofcontents',  1)
+        return nb_text
 
 
     def postprocess(self, nb_text):
@@ -524,6 +533,8 @@ class LenvsLatexExporter(LatexExporter):
             newtext = newtext.replace('\\maketitle', '')
             newtext = newtext.replace('\\tableofcontents', '')
             nb_text = newtext
+        if self.config_title:
+            nb_text = self.configure_title(nb_text)
         if self.tocrefRemove:
             nb_text = self.tocrefrm(nb_text)
         return nb_text

--- a/src/latex_envs/latex_envs.py
+++ b/src/latex_envs/latex_envs.py
@@ -415,7 +415,9 @@ class LenvsLatexExporter(LatexExporter):
     """
 
     config_title = Bool(
-        True, help="Proper Title Format").tag(config=True, alias="rh")
+        True, help="Proper Title Format").tag(config=True, alias="ct")
+    config_biblio = Bool(
+        True, help="Easy Bibliography Formatting").tag(config=True, alias="cb")
     removeHeaders = Bool(
         False, help="Remove headers and footers").tag(config=True, alias="rh")
     figcaptionProcess = Bool(
@@ -513,6 +515,16 @@ class LenvsLatexExporter(LatexExporter):
         nb_text = nb_text.replace('\\maketitle', '\\maketitle\n\\tableofcontents',  1)
         return nb_text
 
+    def configure_bibliography(self, nb_text):
+        # enter your bibliography name here
+        bibliography_name = "math"
+        # enter your preferred bibliography style here 
+        bibliography_style = "unsrt"
+        # construct the string which will insert this information into the document 
+        str = '\n\\bibliographystyle{' + bibliography_style + '}\n\\bibliography{' + bibliography_name +'}'
+        # replace the current generated text (which causes errors) with the desired text
+        nb_text = nb_text.replace(r'\hypertarget{references}{%', str)
+        return nb_text
 
     def postprocess(self, nb_text):
         nb_text = nb_text.replace('!nl!', '\n')
@@ -535,6 +547,8 @@ class LenvsLatexExporter(LatexExporter):
             nb_text = newtext
         if self.config_title:
             nb_text = self.configure_title(nb_text)
+        if self.config_biblio:
+            nb_text = self.configure_bibliography(nb_text)
         if self.tocrefRemove:
             nb_text = self.tocrefrm(nb_text)
         return nb_text

--- a/src/latex_envs/templates/thmsInNb_article.tplx
+++ b/src/latex_envs/templates/thmsInNb_article.tplx
@@ -7,13 +7,6 @@
 ((* block h5 -*))\subparagraph((* endblock h5 -*))
 
 
-((* block abstract *))
-\tableofcontents
-((* endblock abstract *))
-
-%or?
-%((* block toc *))\tableofcontents((* endblock toc *))
-
 
 %===============================================================================
 % My custom output style
@@ -38,19 +31,12 @@
 %((*- block output_prompt -*))
 %((*- endblock output_prompt -*))
 
-
-((* block author *))
-\author{J.-F. Bercher}
-((* endblock author *))
-
-((* block title *))
-\title{ }
-((* endblock title *))
-
 ((* block packages *))
 ((( super() )))
     \usepackage{listings} % Used to define pretty listings for code sections [jfb]
     \usepackage{float}   
+    \usepackage{amsthm}
+    \newtheorem{theorem}{Theorem}   
 ((* endblock packages *))
 
 %or -- both work

--- a/src/latex_envs/templates/thmsInNb_article.tplx
+++ b/src/latex_envs/templates/thmsInNb_article.tplx
@@ -33,9 +33,11 @@
 
 ((* block packages *))
 ((( super() )))
+    \usepackage[nottoc,numbib]{tocbibind} % add the bibliography to the TOC
     \usepackage{listings} % Used to define pretty listings for code sections [jfb]
     \usepackage{float}   
     \usepackage{amsthm}
+    \usepackage{amsmath}
     \newtheorem{theorem}{Theorem}  
     \newtheorem{definition}{Definition}   
     \newtheorem{proposition}{Proposition}   
@@ -142,9 +144,11 @@ framesep=10pt,
 
 
 ((* block bibliography *))
-%\bibliographystyle{ieetran}
-%\bibliography{Thesis}
+% EDIT THE 2 LINES BELOW TO CUSTOMIZE BIBLIOGRAPHY 
+%\bibliographystyle{unsrt}
+%\bibliography{math}
 ((* endblock bibliography *))
+
 
 ((*- block data_png -*))
      ((( draw_figure_with_caption(output,'image/png',cell) )))

--- a/src/latex_envs/templates/thmsInNb_article.tplx
+++ b/src/latex_envs/templates/thmsInNb_article.tplx
@@ -36,7 +36,16 @@
     \usepackage{listings} % Used to define pretty listings for code sections [jfb]
     \usepackage{float}   
     \usepackage{amsthm}
-    \newtheorem{theorem}{Theorem}   
+    \newtheorem{theorem}{Theorem}  
+    \newtheorem{definition}{Definition}   
+    \newtheorem{proposition}{Proposition}   
+    \newtheorem{lemma}{Lemma}   
+    \newtheorem{corollary}{Corollary}   
+    \newtheorem{property}{Property}
+    \newtheorem{problem}{Promlem}
+    \newtheorem{exercise}{Exercise}
+    \newtheorem{example}{Example}
+    \newtheorem{remark}{Remark} 
 ((* endblock packages *))
 
 %or -- both work


### PR DESCRIPTION
Addressed several issues with conversion from .ipynb to .tex via `latex_with_lenvs` in the file `latex_envs.py`

1. Fixed #47 which caused a compilation error in Python 3.6/3.7
2. I also fixed a bug where the references section of the TeX document was incomplete and caused the TeX document to be unable to compile. 
3. Some points for future work: Unfortunately, I couldn't figure out how to access the bibtex bibliography name that the user enters in the GUI. Thus at the moment, the user has to edit the variable `bibliography_name` in `latex_envs.py` to specify their bibtex library name. It might also be good to set up a command line argument where the user can specify their bibtex library name.

I also made several changes to the article style.
1. The title and author of the .ipynb is now used directly as the title of the article (Fixed #49).
2. Added the References section to the ToC. 