### PR TITLE
Fix help menu URL to local documentation and attached image rendering

### DIFF
--- a/src/latex_envs/static/initNb.js
+++ b/src/latex_envs/static/initNb.js
@@ -223,13 +223,15 @@ function init_config(Jupyter,utils,configmod, callback) {
         if ($('#latex_envs_help').length > 0) {
             return;
         }
+
+        var baseUrl = require('base/js/utils').get_body_data("baseUrl")
         var menu_item = $('<li/>')
             .insertAfter('#keyboard_shortcuts');
         var menu_link = $('<a/>')
             .text('LaTeX_envs help')
             .attr('title', 'LaTeX_envs documentation')
             .attr('id', "latex_envs_help")
-            .attr('href', '/nbextensions/latex_envs/doc/latex_env_doc.html')
+            .attr('href', baseUrl + 'nbextensions/latex_envs/doc/latex_env_doc.html')
             .attr('target', "_blank")
             .appendTo(menu_item);
         $('<i/>')

--- a/src/latex_envs/static/latex_envs.js
+++ b/src/latex_envs/static/latex_envs.js
@@ -217,10 +217,10 @@ define(function (require, exports, module) {
                 var ch = line[cur.ch]
                 // get the current word
                 if (!editor.somethingSelected()) {
-                    var re = /[\w]/
-                    var cur = editor.getCursor(),
-                        line = editor.getLine(cur.line),
-                        start = cur.ch,
+                    var re = /[\w]/;
+                    cur = editor.getCursor();
+                    line = editor.getLine(cur.line);
+                    var start = cur.ch,
                         end = start;
                     while (start && re.test(line.charAt(start - 1))) {
                         --start;
@@ -236,10 +236,10 @@ define(function (require, exports, module) {
                     // if word starts with \, then autocomplete
                     if (line[start - 1] == "\\") {
                         // console.log("Completion in order");
-                        var array_completion = ['text ', 'textit{}', 'textbf{}', 'texttt{}', 'emph{}',
+                        array_completion = ['text ', 'textit{}', 'textbf{}', 'texttt{}', 'emph{}',
                             'cite{}', 'ref{}', 'underline{}', 'title{}', 'begin{}', 'end{}', 'label{}'
                         ]
-                        var matches = array_completion.filter(function (elt) {
+                        matches = array_completion.filter(function (elt) {
                             return elt.startsWith(word_before)
                         })
                         if (matches.length > 0) {

--- a/src/latex_envs/static/latex_envs.js
+++ b/src/latex_envs/static/latex_envs.js
@@ -76,10 +76,10 @@ function insert_text(identifier) { //must be available in the main scope
     selected_cell.code_mirror.replaceSelection(
         String($(identifier).data('text')), 'start');
     if (typeof $(identifier).data('position') !== "undefined") {
-        var deltaPos = $(identifier).data('position').split(',').map(Number)
+        deltaPos = $(identifier).data('position').split(',').map(Number)
     }
     selected_cell.code_mirror.setCursor(cursorPos['line'] + deltaPos[0], deltaPos[1])
-    var cursorPos = selected_cell.code_mirror.getCursor();
+    cursorPos = selected_cell.code_mirror.getCursor();
     selected_cell.code_mirror.replaceRange(selectedText, cursorPos);
 }
 

--- a/src/latex_envs/static/latex_envs.js
+++ b/src/latex_envs/static/latex_envs.js
@@ -163,6 +163,20 @@ define(function (require, exports, module) {
                     });
                     // links in markdown cells should open in new tabs
                     html.find("a[href]").not('[href^="#"]').attr("target", "_blank");
+                    // replace attachment:<key> by the corresponding entry
+                    // in the cell's attachments
+                    html.find('img[src^="attachment:"]').each(function (i, h) {
+                        h = $(h);
+                        var key = h.attr('src').replace(/^attachment:/, '');
+
+                        if (that.attachments.hasOwnProperty(key)) {
+                            var att = that.attachments[key];
+                            var mime = Object.keys(att)[0];
+                            h.attr('src', 'data:' + mime + ';base64,' + att[mime]);
+                        } else {
+                            h.attr('src', '');
+                        }
+                    });
                     that.set_rendered(html);
                     that.typeset();
                     if (!noevent)

--- a/src/latex_envs/static/latex_envs.js
+++ b/src/latex_envs/static/latex_envs.js
@@ -6,7 +6,7 @@
 
 var conversion_to_html = false;
 var config_toolbar_present = false;
-var reprocessEqs; 
+var reprocessEqs;
 //These variables are initialized in init_config()
 var cite_by, bibliofile, eqNumInitial, eqNum, eqLabelWithNumbers, LaTeX_envs_menu_present, labels_anchors, latex_user_defs, user_envs_cfg;
 var environmentMap = {};
@@ -27,12 +27,13 @@ if (MathJaxDefined) {
                 autoNumber: "AMS", // All AMS equations are numbered
                 useLabelIds: true, // labels as ids
                 // format the equation number - uses an offset eqNumInitial-1 (default 0) ie number from 1
-                formatNumber: function(n) {
-                    return String(Number(n) + Number(eqNumInitial) - 1) }
+                formatNumber: function (n) {
+                    return String(Number(n) + Number(eqNumInitial) - 1)
+                }
             }
         }
     });
-   // MathJax.Hub.processSectionDelay = 0; //commented For Jupyter 5.0 ??
+    // MathJax.Hub.processSectionDelay = 0; //commented For Jupyter 5.0 ??
 }
 
 /* *************************************************************************************
@@ -47,22 +48,22 @@ var current_cit = current_citInitial; // begins citation numbering at current_ci
 
 var etal = 3; //list of authors is completed by et al. if there is more than etal authors
 var cit_tpl = {
-        // feel free to add more types and customize the templates
-        'INPROCEEDINGS': '%AUTHOR:InitialsGiven%, ``_%TITLE%_\'\', %BOOKTITLE%, %MONTH% %YEAR%.',
-        'TECHREPORT': '%AUTHOR%, ``%TITLE%\'\', %INSTITUTION%, number: %NUMBER%,  %MONTH% %YEAR%.',
-        'ARTICLE': '%AUTHOR:GivenFirst%, ``_%TITLE%_\'\', %JOURNAL%, vol. %VOLUME%, number %NUMBER%, pp. %PAGES%, %MONTH% %YEAR%.',
-        'INBOOK': '%AUTHOR:Given%, ``_%TITLE%_\'\', in %BOOKTITLE%, %EDITION%, %PUBLISHER%, pp. %PAGES%, %MONTH% %YEAR%.',
-        'UNKNOWN': '%AUTHOR:FirstGiven%, ``_%TITLE%_\'\', %MONTH% %YEAR%.'
-    }
-    /* The keys are the main types of documents, eg inproceedings, article, inbook, etc. To each key is associated a string where the %KEYWORDS% are the fields of the bibtex entry. The keywords are replaced by the correponding bibtex entry value. The template string can formatted with additional words and effects (markdown or LaTeX are commands are supported)
+    // feel free to add more types and customize the templates
+    'INPROCEEDINGS': '%AUTHOR:InitialsGiven%, ``_%TITLE%_\'\', %BOOKTITLE%, %MONTH% %YEAR%.',
+    'TECHREPORT': '%AUTHOR%, ``%TITLE%\'\', %INSTITUTION%, number: %NUMBER%,  %MONTH% %YEAR%.',
+    'ARTICLE': '%AUTHOR:GivenFirst%, ``_%TITLE%_\'\', %JOURNAL%, vol. %VOLUME%, number %NUMBER%, pp. %PAGES%, %MONTH% %YEAR%.',
+    'INBOOK': '%AUTHOR:Given%, ``_%TITLE%_\'\', in %BOOKTITLE%, %EDITION%, %PUBLISHER%, pp. %PAGES%, %MONTH% %YEAR%.',
+    'UNKNOWN': '%AUTHOR:FirstGiven%, ``_%TITLE%_\'\', %MONTH% %YEAR%.'
+}
+/* The keys are the main types of documents, eg inproceedings, article, inbook, etc. To each key is associated a string where the %KEYWORDS% are the fields of the bibtex entry. The keywords are replaced by the correponding bibtex entry value. The template string can formatted with additional words and effects (markdown or LaTeX are commands are supported)
 
-    Authors can be formatted according to the following keywords:
-    - %AUTHOR:FirstGiven%, i.e. John Smith
-    - %AUTHOR:GivenFirst%, i.e. Smith John
-    - %AUTHOR:InitialsGiven%, i.e. J. Smith
-    - %AUTHOR:GivenInitials%, i.e. Smith J.
-    - %AUTHOR:Given%, i.e. Smith
-    */
+Authors can be formatted according to the following keywords:
+- %AUTHOR:FirstGiven%, i.e. John Smith
+- %AUTHOR:GivenFirst%, i.e. Smith John
+- %AUTHOR:InitialsGiven%, i.e. J. Smith
+- %AUTHOR:GivenInitials%, i.e. Smith J.
+- %AUTHOR:Given%, i.e. Smith
+*/
 
 // *****************************************************************************
 
@@ -78,14 +79,14 @@ function insert_text(identifier) { //must be available in the main scope
         var deltaPos = $(identifier).data('position').split(',').map(Number)
     }
     selected_cell.code_mirror.setCursor(cursorPos['line'] + deltaPos[0], deltaPos[1])
-    var cursorPos = selected_cell.code_mirror.getCursor()    
-    selected_cell.code_mirror.replaceRange(selectedText, cursorPos);    
+    var cursorPos = selected_cell.code_mirror.getCursor();
+    selected_cell.code_mirror.replaceRange(selectedText, cursorPos);
 }
 
 // use AMD-style simplified define wrapper to avoid https://requirejs.org/docs/errors.html#notloaded
 // `define(['notebook'], function(notebookApp) { var module =  notebookApp['base/js/utils']});`
 
-define(function(require, exports, module) {
+define(function (require, exports, module) {
     var Jupyter = require('base/js/namespace');
     var MarkdownCell = require('notebook/js/textcell').MarkdownCell;
     var TextCell = require('notebook/js/textcell').TextCell;
@@ -96,8 +97,8 @@ define(function(require, exports, module) {
     var marked = require('components/marked/lib/marked');
     // var completer = require('notebook/js/completer')
     var codemirror = require('codemirror/lib/codemirror');
-    var showhint  = require("codemirror/addon/hint/show-hint")
-    var anyword  = require("codemirror/addon/hint/anyword-hint")
+    var showhint = require("codemirror/addon/hint/show-hint");
+    var anyword = require("codemirror/addon/hint/anyword-hint");
 
     var thmsInNb = require('nbextensions/latex_envs/thmsInNb4');
     var bibsInNb = require('nbextensions/latex_envs/bibInNb4');
@@ -106,7 +107,7 @@ define(function(require, exports, module) {
 
     cfg = Jupyter.notebook.metadata.latex_envs;
 
-    var load_css = function(name) {
+    var load_css = function (name) {
         var link = document.createElement("link");
         link.type = "text/css";
         link.rel = "stylesheet";
@@ -123,39 +124,41 @@ define(function(require, exports, module) {
         /* Override original markdown render function to include latex_envs 
         processing */
 
-        MarkdownCell.prototype.render = function(noevent) {
+        MarkdownCell.prototype.render = function (noevent) {
             if (typeof noevent === "undefined") noevent = false;
             var cont = TextCell.prototype.render.apply(this);
             if (cont || Jupyter.notebook.dirty || _on_reload) {
                 var that = this;
                 var text = this.get_text();
                 // interpret \[..\] and \(\) as LaTeX
-                text = text.replace(/\\\[([\s\S]*?)\\\]/gm, function(w, m1) {
+                text = text.replace(/\\\[([\s\S]*?)\\\]/gm, function (w, m1) {
                     return "$$" + m1 + "$$"
                 })
-                text = text.replace(/\\\(([\s\S]*?)\\\)/gm, function(w, m1) {
+                text = text.replace(/\\\(([\s\S]*?)\\\)/gm, function (w, m1) {
                     return "$" + m1 + "$"
                 })
                 var math = null;
-                if (text === "") { text = this.placeholder; }
+                if (text === "") {
+                    text = this.placeholder;
+                }
                 var text_and_math = mathjaxutils.remove_math(text);
                 text = text_and_math[0];
                 math = text_and_math[1];
-                marked(text, function(err, html) {
+                marked(text, function (err, html) {
                     html = mathjaxutils.replace_math(html, math);
                     html = thmsInNbConv(marked, html); //<----- thmsInNb patch here
                     html = security.sanitize_html(html);
                     html = $($.parseHTML(html));
                     // add anchors to headings
-                    html.find(":header").addBack(":header").each(function(i, h) {
+                    html.find(":header").addBack(":header").each(function (i, h) {
                         h = $(h);
                         var hash = h.text().replace(/ /g, '-');
                         h.attr('id', hash);
                         h.append(
                             $('<a/>')
-                            .addClass('anchor-link')
-                            .attr('href', '#' + hash)
-                            .text('¶')
+                                .addClass('anchor-link')
+                                .attr('href', '#' + hash)
+                                .text('¶')
                         );
                     });
                     // links in markdown cells should open in new tabs
@@ -163,7 +166,7 @@ define(function(require, exports, module) {
                     that.set_rendered(html);
                     that.typeset();
                     if (!noevent)
-                        that.events.trigger("rendered.MarkdownCell", { cell: that });
+                        that.events.trigger("rendered.MarkdownCell", {cell: that});
                 });
             }
             return cont;
@@ -176,7 +179,7 @@ define(function(require, exports, module) {
         }
 
 
-        MarkdownCell.prototype.handle_codemirror_keyevent = function(editor, event) {
+        MarkdownCell.prototype.handle_codemirror_keyevent = function (editor, event) {
 
             require('notebook/js/cell').Cell.prototype.handle_codemirror_keyevent.apply(this, [editor, event]);
             var cur = editor.getCursor();
@@ -193,7 +196,7 @@ define(function(require, exports, module) {
             var tst = inWord_re.test(pre_cursor)
 
             var array_completion = ['$$', '()', '[]', '{}']
-            var matches = array_completion.filter(function(elt) {
+            var matches = array_completion.filter(function (elt) {
                 return elt.startsWith(event.key)
             })
             if (cfg.autoclose) {
@@ -212,7 +215,7 @@ define(function(require, exports, module) {
                 var inchar = event.key.length == 1 ? event.key : ""
                 var posx = cur.ch
                 var ch = line[cur.ch]
-                    // get the current word
+                // get the current word
                 if (!editor.somethingSelected()) {
                     var re = /[\w]/
                     var cur = editor.getCursor(),
@@ -236,13 +239,13 @@ define(function(require, exports, module) {
                         var array_completion = ['text ', 'textit{}', 'textbf{}', 'texttt{}', 'emph{}',
                             'cite{}', 'ref{}', 'underline{}', 'title{}', 'begin{}', 'end{}', 'label{}'
                         ]
-                        var matches = array_completion.filter(function(elt) {
+                        var matches = array_completion.filter(function (elt) {
                             return elt.startsWith(word_before)
                         })
                         if (matches.length > 0) {
                             event.codemirrorIgnore = true;
                             event.preventDefault();
-                            editor.replaceRange(matches[0], { line: cur.line, ch: start }, { line: cur.line, ch: cur.ch });
+                            editor.replaceRange(matches[0], {line: cur.line, ch: start}, {line: cur.line, ch: cur.ch});
                             editor.setCursor(cur.line, start + matches[0].length - 1);
                             return true
                         }
@@ -255,53 +258,54 @@ define(function(require, exports, module) {
     }
 
 
-function load_ipython_extension() {
-    //var load_ipython_extension = require(['base/js/namespace'], function(Jupyter) {
+    function load_ipython_extension() {
+        //var load_ipython_extension = require(['base/js/namespace'], function(Jupyter) {
 
-    "use strict";
-    if (Jupyter.version[0] < 3) {
-        console.log("This extension requires Jupyter or IPython >= 3.x")
-        return
-    }
+        "use strict";
+        if (Jupyter.version[0] < 3) {
+            console.log("This extension requires Jupyter or IPython >= 3.x")
+            return
+        }
 
-    var environmentMap = {};
-    
-    if (Jupyter.notebook._fully_loaded) {  
-        // this tests if the notebook is fully loaded              
-        var initcfg = init_config(Jupyter, utils, configmod, override_mdrenderer);
-        cfg = Jupyter.notebook.metadata.latex_envs;
-        console.log("Notebook fully loaded -- latex_envs initialized ")
-    } else {
-        $([Jupyter.events]).on("notebook_loaded.Notebook", function() {
-            init_config(Jupyter, utils, configmod, override_mdrenderer);
+        var environmentMap = {};
+
+        if (Jupyter.notebook._fully_loaded) {
+            // this tests if the notebook is fully loaded
+            var initcfg = init_config(Jupyter, utils, configmod, override_mdrenderer);
             cfg = Jupyter.notebook.metadata.latex_envs;
-            console.log("latex_envs initialized (via notebook_loaded)")
-        })
-    }
+            console.log("Notebook fully loaded -- latex_envs initialized ")
+        } else {
+            $([Jupyter.events]).on("notebook_loaded.Notebook", function () {
+                init_config(Jupyter, utils, configmod, override_mdrenderer);
+                cfg = Jupyter.notebook.metadata.latex_envs;
+                console.log("latex_envs initialized (via notebook_loaded)")
+            })
+        }
 
 
-    // toolbar buttons
+        // toolbar buttons
         var toolbarButtons = Jupyter.toolbar.add_buttons_group([
 
-			Jupyter.keyboard_manager.actions.register ({
-		        help: 'LaTeX_envs: Refresh rendering of labels, equations and citations',
-		        icon: 'fa-refresh',
-		        handler: init_cells
-        }, 'init_cells', 'latex_envs'),
+            Jupyter.keyboard_manager.actions.register({
+                help: 'LaTeX_envs: Refresh rendering of labels, equations and citations',
+                icon: 'fa-refresh',
+                handler: init_cells
+            }, 'init_cells', 'latex_envs'),
 
-		Jupyter.keyboard_manager.actions.register ({
-             help: 'Read bibliography and generate references section',
-             icon: 'fa-book',
-             handler: generateReferences
-        }, 'generateReferences', 'latex_envs'),
+            Jupyter.keyboard_manager.actions.register({
+                help: 'Read bibliography and generate references section',
+                icon: 'fa-book',
+                handler: generateReferences
+            }, 'generateReferences', 'latex_envs'),
 
-		 Jupyter.keyboard_manager.actions.register ({
-             	help: 'LaTeX_envs: Some configuration options (toogle toolbar)',
-             	icon: 'fa-wrench',
-            	handler: config_toolbar}, 'confToolbar', 'latex_envs')
-		]);
+            Jupyter.keyboard_manager.actions.register({
+                help: 'LaTeX_envs: Some configuration options (toogle toolbar)',
+                icon: 'fa-wrench',
+                handler: config_toolbar
+            }, 'confToolbar', 'latex_envs')
+        ]);
 
-	toolbarButtons.find('.btn').eq(0).attr('id', 'doReload');
+        toolbarButtons.find('.btn').eq(0).attr('id', 'doReload');
 
     }  //end of load_ipython_extension function
 

--- a/src/latex_envs/static/thmsInNb4.js
+++ b/src/latex_envs/static/thmsInNb4.js
@@ -1,6 +1,6 @@
 
 /*
-This script goes through the input text (actually it is triggered each time a markdown cell is rendered. The imput text is the content of the cell.
+This script goes through the input text (actually it is triggered each time a markdown cell is rendered. The input text is the content of the cell.
 It replaces the latex structures by html tags, typically with a <div class="latex_environment_name> ... </div>. Then the html rendering 
 can be customized using a devoted css. The original idea comes from
 https://github.com/benweet/stackedit/issues/187


### PR DESCRIPTION
The URL under Help menu in a notebook did not take into account base URL of the notebook. This matters where the notebook server is spawned from Jupyter Hub and URLs are relative to base URL and not just server location.